### PR TITLE
Just-Checking-Locally- [cli-221] added new Option.Builder.listValueSeparator() to allow to p…

### DIFF
--- a/src/main/java/org/apache/commons/cli/Char.java
+++ b/src/main/java/org/apache/commons/cli/Char.java
@@ -40,6 +40,9 @@ final class Char {
     /** Tab. */
     static final char TAB = '\t';
 
+    /** Comma. */
+    static final char COMMA = ',';
+
     private Char() {
         // empty
     }

--- a/src/main/java/org/apache/commons/cli/DefaultParser.java
+++ b/src/main/java/org/apache/commons/cli/DefaultParser.java
@@ -609,6 +609,9 @@ public class DefaultParser implements CommandLineParser {
                 skipParsing = true;
             } else if (currentOption != null && currentOption.acceptsArg() && isArgument(token)) {
                 currentOption.processValue(stripLeadingAndTrailingQuotesDefaultOn(token));
+                if (currentOption.areValuesAsList()) {
+                    currentOption = null;
+                }
             } else if (token.startsWith("--")) {
                 handleLongOption(token);
             } else if (token.startsWith("-") && !"-".equals(token)) {

--- a/src/main/java/org/apache/commons/cli/DefaultParser.java
+++ b/src/main/java/org/apache/commons/cli/DefaultParser.java
@@ -609,7 +609,7 @@ public class DefaultParser implements CommandLineParser {
                 skipParsing = true;
             } else if (currentOption != null && currentOption.acceptsArg() && isArgument(token)) {
                 currentOption.processValue(stripLeadingAndTrailingQuotesDefaultOn(token));
-                if (currentOption.areValuesAsList()) {
+                if (currentOption.isValueSeparatorUsedForSingleArgument()) {
                     currentOption = null;
                 }
             } else if (token.startsWith("--")) {

--- a/src/main/java/org/apache/commons/cli/Option.java
+++ b/src/main/java/org/apache/commons/cli/Option.java
@@ -103,7 +103,7 @@ public class Option implements Cloneable, Serializable {
         private char valueSeparator;
 
         /** multiple values are within a single argument separated by valueSeparator char */
-        private boolean valuesAsList;
+        private boolean valueSeparatorUsedForSingleArgument;
 
         /**
          * Constructs a new {@code Builder} with the minimum required parameters for an {@code Option} instance.
@@ -318,7 +318,7 @@ public class Option implements Cloneable, Serializable {
         }
 
         /**
-         * The Option will use {@code sep} as a means to separate java-property-style argument values
+         * The Option will use {@code sep} as a means to separate java-property-style argument values.
          *
          * Method is mutually exclusive to listValueSeparator() method.
          * <p>
@@ -336,7 +336,7 @@ public class Option implements Cloneable, Serializable {
          * String propertyValue = line.getOptionValues("D")[1]; // will be "value"
          * </pre>
          *
-         * In the above example (unlimited args), followup arguments are interpreted
+         * In the above example, followup arguments are interpreted
          * to be additional values to this option, needs to be terminated with -- so that
          * others options or args can follow.
          *
@@ -359,26 +359,28 @@ public class Option implements Cloneable, Serializable {
         }
 
         /**
-         * defines the separator used to separate a list of values passed in a single arg
+         * defines the separator used to split a list of values passed in a single argument.
          *
-         * Method is mutually exclusive to valueSeparator() method.
+         * Method is mutually exclusive to valueSeparator() method. In the resulting option,
+         * isValueSeparatorUsedForSingleArgument() will return true.
+         *
          * <p>
          * <strong>Example:</strong>
          * </p>
          *
          * <pre>
-         * final Option colors = Option.builder().option("c").longOpt("colors").hasArgs().listValueSeparator('|').build();
+         * final Option colors = Option.builder().option("c").hasArgs().listValueSeparator('|').build();
          * final Options options = new Options();
          * options.addOption(colors);
          *
          * final String[] args = {"-c", "red|blue|yellow", "b,c"};
          * final DefaultParser parser = new DefaultParser();
          * final CommandLine commandLine = parser.parse(options, args, null, true);
-         * String [] colorValues = commandLine.getOptionValues(colors);
+         * final String [] colorValues = commandLine.getOptionValues(colors);
          * // colorValues[0] will be "red"
          * // colorValues[1] will be "blue"
          * // colorValues[2] will be "yellow"
-         * String arguments = commandLine.getArgs()[0]; // will be b,c
+         * final String arguments = commandLine.getArgs()[0]; // will be b,c
          *
          * </pre>
          *
@@ -388,7 +390,7 @@ public class Option implements Cloneable, Serializable {
          */
         public Builder listValueSeparator(final char listValueSeparator) {
             this.valueSeparator = listValueSeparator;
-            this.valuesAsList = true;
+            this.valueSeparatorUsedForSingleArgument = true;
             return this;
         }
     }
@@ -472,7 +474,7 @@ public class Option implements Cloneable, Serializable {
     private char valueSeparator;
 
     /** multiple values are within a single argument separated by valueSeparator char */
-    private boolean valuesAsList;
+    private boolean valueSeparatorUsedForSingleArgument;
 
     /**
      * Private constructor used by the nested Builder class.
@@ -492,7 +494,7 @@ public class Option implements Cloneable, Serializable {
         this.type = builder.type;
         this.valueSeparator = builder.valueSeparator;
         this.converter = builder.converter;
-        this.valuesAsList = builder.valuesAsList;
+        this.valueSeparatorUsedForSingleArgument = builder.valueSeparatorUsedForSingleArgument;
     }
 
     /**
@@ -877,13 +879,24 @@ public class Option implements Cloneable, Serializable {
     }
 
     /**
-     * Tests whether multiple values are expected in a single argument separated by a separation character
+     * Tests whether multiple values are expected in a single argument split by a separation character
      *
-     * @return boolean true when multiple values are expected in a single separated by a separation character
+     * @return boolean true when the builder's listValueSeparator() method was used. Multiple values are expected in a single argument and
+     *                 are split by a separation character.
      * @since 1.10.0
      */
-    public boolean areValuesAsList() {
-        return valuesAsList;
+    public boolean isValueSeparatorUsedForSingleArgument() {
+        return valueSeparatorUsedForSingleArgument;
+    }
+
+    /**
+     * Set this to true to use the valueSeparator only on a single argument. See also builder's listValueSeparator() method.
+     *
+     * @param valueSeparatorUsedForSingleArgument the new value for this property
+     * @since 1.10.0
+     */
+    public void setValueSeparatorUsedForSingleArgument(final boolean valueSeparatorUsedForSingleArgument) {
+        this.valueSeparatorUsedForSingleArgument = valueSeparatorUsedForSingleArgument;
     }
 
     /**

--- a/src/test/java/org/apache/commons/cli/DefaultParserTest.java
+++ b/src/test/java/org/apache/commons/cli/DefaultParserTest.java
@@ -339,8 +339,8 @@ class DefaultParserTest extends AbstractParserTestCase {
         final String[] args = {"-c", "red|blue|yellow", "b,c"};
         final DefaultParser parser = new DefaultParser();
         final CommandLine commandLine = parser.parse(options, args, null, true);
-        String [] colorValues = commandLine.getOptionValues(colors);
-        assertEquals(3, colorValues.length );
+        final String [] colorValues = commandLine.getOptionValues(colors);
+        assertEquals(3, colorValues.length);
         assertEquals("red", colorValues[0]);
         assertEquals("blue", colorValues[1]);
         assertEquals("yellow", colorValues[2]);
@@ -350,18 +350,18 @@ class DefaultParserTest extends AbstractParserTestCase {
     @ParameterizedTest
     @ValueSource(strings = {
             "--colors=red,blue,yellow b",
-            "--colors red,blue,yellow b" ,
-            "-c=red,blue,yellow b" ,
-            "-c red,blue,yellow b" })
-    void listValueSeparatorDefaultTest(String args) throws ParseException {
+            "--colors red,blue,yellow b",
+            "-c=red,blue,yellow b",
+            "-c red,blue,yellow b"})
+    void listValueSeparatorDefaultTest(final String args) throws ParseException {
         final Option colors = Option.builder().option("c").longOpt("colors").hasArgs().listValueSeparator().build();
         final Options options = new Options();
         options.addOption(colors);
 
         final DefaultParser parser = new DefaultParser();
         final CommandLine commandLine = parser.parse(options, args.split(" "), null, true);
-        String [] colorValues = commandLine.getOptionValues(colors);
-        assertEquals(3, colorValues.length );
+        final String [] colorValues = commandLine.getOptionValues(colors);
+        assertEquals(3, colorValues.length);
         assertEquals("red", colorValues[0]);
         assertEquals("blue", colorValues[1]);
         assertEquals("yellow", colorValues[2]);
@@ -386,7 +386,7 @@ class DefaultParserTest extends AbstractParserTestCase {
         final CommandLine commandLine = parser.parse(options, args.split(" "), null, false);
         final String [] colorValues = commandLine.getOptionValues(colors);
         final String fooValue = commandLine.getOptionValue(foo);
-        assertEquals(3, colorValues.length );
+        assertEquals(3, colorValues.length);
         assertEquals("red", colorValues[0]);
         assertEquals("blue", colorValues[1]);
         assertEquals("yellow", colorValues[2]);

--- a/src/test/java/org/apache/commons/cli/OptionTest.java
+++ b/src/test/java/org/apache/commons/cli/OptionTest.java
@@ -344,4 +344,28 @@ class OptionTest {
         option.setType(type);
         assertEquals(CharSequence.class, option.getType());
     }
+
+    @Test
+    void testDefaultValueSeparator() {
+        final Option option = Option.builder().option("a").hasArgs().valueSeparator().build();
+        assertFalse(option.areValuesAsList());
+        assertTrue(option.hasValueSeparator());
+        assertEquals('=',option.getValueSeparator());
+    }
+
+    @Test
+    void testDefaultValueAsList() {
+        final Option option = Option.builder().option("a").hasArgs().listValueSeparator().build();
+        assertTrue(option.areValuesAsList());
+        assertTrue(option.hasValueSeparator());
+        assertEquals(',',option.getValueSeparator());
+    }
+    
+    @Test
+    void testValueAsList() {
+        final Option option = Option.builder().option("a").hasArgs().listValueSeparator('|').build();
+        assertTrue(option.areValuesAsList());
+        assertTrue(option.hasValueSeparator());
+        assertEquals('|',option.getValueSeparator());
+    }
 }

--- a/src/test/java/org/apache/commons/cli/OptionTest.java
+++ b/src/test/java/org/apache/commons/cli/OptionTest.java
@@ -348,24 +348,30 @@ class OptionTest {
     @Test
     void testDefaultValueSeparator() {
         final Option option = Option.builder().option("a").hasArgs().valueSeparator().build();
-        assertFalse(option.areValuesAsList());
+        assertFalse(option.isValueSeparatorUsedForSingleArgument());
         assertTrue(option.hasValueSeparator());
-        assertEquals('=',option.getValueSeparator());
+        assertEquals('=', option.getValueSeparator());
     }
 
     @Test
-    void testDefaultValueAsList() {
+    void testDefaultListValueSeparator() {
         final Option option = Option.builder().option("a").hasArgs().listValueSeparator().build();
-        assertTrue(option.areValuesAsList());
+        assertTrue(option.isValueSeparatorUsedForSingleArgument());
         assertTrue(option.hasValueSeparator());
-        assertEquals(',',option.getValueSeparator());
+        assertEquals(',', option.getValueSeparator());
     }
-    
+
     @Test
-    void testValueAsList() {
+    void testListValueSeparator() {
         final Option option = Option.builder().option("a").hasArgs().listValueSeparator('|').build();
-        assertTrue(option.areValuesAsList());
+        assertTrue(option.isValueSeparatorUsedForSingleArgument());
         assertTrue(option.hasValueSeparator());
-        assertEquals('|',option.getValueSeparator());
+        assertEquals('|', option.getValueSeparator());
+
+        option.setValueSeparatorUsedForSingleArgument(false);
+        assertFalse(option.isValueSeparatorUsedForSingleArgument());
+        assertTrue(option.hasValueSeparator());
+        assertEquals('|', option.getValueSeparator());
+
     }
 }


### PR DESCRIPTION
…roperly use options with single argument-commaseparated values. To remain backward compatibility to the java-property-style parsing wth default valueSeparator '=', this mutually exclusive new method needed to be added

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [ ] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible but is a best-practice.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body. Note that commits might be squashed by a maintainer on merge.
